### PR TITLE
Exposing column definition fields

### DIFF
--- a/crates/tomestone-exdf/src/lib.rs
+++ b/crates/tomestone-exdf/src/lib.rs
@@ -137,11 +137,11 @@ impl ColumnFormat {
 #[derive(Debug, Clone)]
 pub struct ColumnDefinition {
     /// Data type of the column.
-    format: ColumnFormat,
+    pub format: ColumnFormat,
     /// Offset of the column inside the fixed-width portion of an encoded row.
-    offset: usize,
+    pub offset: usize,
     /// Index of the column in the table's schema.
-    index: usize,
+    pub index: usize,
 }
 
 #[derive(PartialEq)]


### PR DESCRIPTION
I'm wanting to build generated structs that abstract `tomestone_exdf::Row`, exposing functions like `.field()` based on SaintCoinach's handwritten names and `tomestone_exdf::ColumnDefinition`, but the fields aren't exposed publicly. If you have no objections, I would love if these fields could be made public.

I could achieve something similar currently by reading the first row, but it would be much nicer to work based on the column definitions themselves.

Thanks for writing this excellent project by the way!